### PR TITLE
Revert "DAC6-428: Add crsf to upload form"

### DIFF
--- a/conf/views/upload-form.njk
+++ b/conf/views/upload-form.njk
@@ -30,8 +30,6 @@
 
 <form id="dac6UploadForm" action="{{upscanInitiateResponse.postTarget}}" method="post" enctype="multipart/form-data">
 
-    {{ csrf() | safe }}
-
     {% for key, value in upscanInitiateResponse.formFields %}
     <input type="hidden" name="{{key}}" value="{{value}}"/>
     {% endfor %}


### PR DESCRIPTION
Reverts hmrc/disclose-cross-border-arrangements-frontend#124
Upscan maintains its own form elements - write a zap exclusion